### PR TITLE
docs: make Let's Encrypt certificate instructions generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,12 +595,12 @@ spec:
 
         #### Let's Encrypt
 
-        - **Root**: ISRG Root X1
-        - **Intermediate**: R3
+        Let's Encrypt periodically rotates its root and intermediate certificates. Always refer to their official certificates page for the current active chain.
 
         **How to Get:**
         - Browse to: https://letsencrypt.org/certificates/
-        - Download both the **ISRG Root X1** and **R3 Intermediate Certificate (PEM format)**.
+        - Identify the currently active **root** and **intermediate** certificates listed on that page.
+        - Download both certificates in **PEM format**.
 
         #### Google Certificate Authority Service (CAS)
 

--- a/docsource/configuration.md
+++ b/docsource/configuration.md
@@ -533,12 +533,12 @@ Here is how to obtain the root and intermediate CA certificates from supported A
 
 #### Let's Encrypt
 
-- **Root**: ISRG Root X1
-- **Intermediate**: R3
+Let's Encrypt periodically rotates its root and intermediate certificates. Always refer to their official certificates page for the current active chain.
 
 **How to Get:**
 - Browse to: https://letsencrypt.org/certificates/
-- Download both the **ISRG Root X1** and **R3 Intermediate Certificate (PEM format)**.
+- Identify the currently active **root** and **intermediate** certificates listed on that page.
+- Download both certificates in **PEM format**.
 
 #### Google Certificate Authority Service (CAS)
 


### PR DESCRIPTION
Removed specific root/intermediate names (ISRG Root X1, R3) that go stale when Let's Encrypt rotates their chain. Users are now directed to the official Let's Encrypt certificates page to identify the currently active root and intermediate certificates.