### PR TITLE
Add multi-level CNAME delegation support for DNS-01 challenges

### DIFF
--- a/AcmeCaPlugin/AcmeCaPlugin.cs
+++ b/AcmeCaPlugin/AcmeCaPlugin.cs
@@ -642,7 +642,8 @@ namespace Keyfactor.Extensions.CAPlugin.Acme
             }
 
             var dnsVerifier = new DnsVerificationHelper(_logger, config.DnsVerificationServer);
-            var pendingChallenges = new List<(Authorization authz, Challenge challenge, Dns01ChallengeValidationDetails validation, IDomainValidator validator)>();
+            var cnameResolver = new CnameResolver(_logger, config.DnsVerificationServer);
+            var pendingChallenges = new List<(Authorization authz, Challenge challenge, Dns01ChallengeValidationDetails validation, IDomainValidator validator, string recordName)>();
 
             flow.Branch("StageDnsRecords");
             try
@@ -673,36 +674,47 @@ namespace Keyfactor.Extensions.CAPlugin.Acme
                         throw new InvalidOperationException($"Failed to decode {DNS_CHALLENGE_TYPE} challenge validation details for {domain}");
                     }
 
+                    // Follow any chain of CNAME delegations to find the name the TXT record must
+                    // actually be created on. A CNAME cannot coexist with a TXT record at the same
+                    // name (RFC 1034), so a delegated challenge name is resolved to its terminal
+                    // target. Returns the original name unchanged when no delegation exists. The
+                    // resolved name is then used to select the DNS provider plugin, so a challenge
+                    // delegated into a zone on a different provider is routed to the plugin that
+                    // owns that zone.
+                    var recordName = await flow.StepAsync($"ResolveCname:{domain}",
+                        async () => await cnameResolver.ResolveChallengeTargetAsync(validation.DnsRecordName),
+                        detail: $"from {validation.DnsRecordName}");
+
                     var domainValidator = flow.Step($"ResolveValidator:{domain}",
                         () =>
                         {
-                            var v = _validatorFactory.ResolveDomainValidator(domain, DNS_CHALLENGE_TYPE);
+                            var v = _validatorFactory.ResolveDomainValidator(recordName, DNS_CHALLENGE_TYPE);
                             if (v == null)
                             {
                                 throw new InvalidOperationException(
-                                    $"Failed to resolve domain validator for domain '{domain}'. " +
-                                    "Ensure the appropriate DNS provider plugin is deployed and configured for this domain's zone.");
+                                    $"Failed to resolve domain validator for '{recordName}' (challenge for '{domain}'). " +
+                                    "Ensure the appropriate DNS provider plugin is deployed and configured for the zone that hosts the (possibly CNAME-delegated) challenge record.");
                             }
                             return v;
                         });
 
-                    _logger.LogInformation("Using domain validator: {ValidatorType} for domain: {Domain}",
-                        domainValidator.GetType().Name, domain);
+                    _logger.LogInformation("Using domain validator: {ValidatorType} for record: {RecordName} (domain: {Domain})",
+                        domainValidator.GetType().Name, recordName, domain);
 
                     await flow.StepAsync($"StageValidation:{domain}",
                         async () =>
                         {
                             var result = await domainValidator.StageValidation(
-                                validation.DnsRecordName,
+                                recordName,
                                 validation.DnsRecordValue,
                                 CancellationToken.None);
 
                             if (!result.Success)
                                 throw new InvalidOperationException($"Failed to stage DNS validation for {domain}: {result.ErrorMessage}");
                         },
-                        detail: $"{validation.DnsRecordName} via {domainValidator.GetType().Name}");
+                        detail: $"{recordName} via {domainValidator.GetType().Name}");
 
-                    pendingChallenges.Add((authz, challenge, validation, domainValidator));
+                    pendingChallenges.Add((authz, challenge, validation, domainValidator, recordName));
                 }
             }
             finally
@@ -720,7 +732,7 @@ namespace Keyfactor.Extensions.CAPlugin.Acme
             flow.Branch("VerifyAndSubmit");
             try
             {
-                foreach (var (authz, challenge, validation, validator) in pendingChallenges)
+                foreach (var (authz, challenge, validation, validator, recordName) in pendingChallenges)
                 {
                     var domain = authz.Identifier.Value;
                     var validatorTypeName = validator.GetType().Name.ToLowerInvariant();
@@ -735,19 +747,19 @@ namespace Keyfactor.Extensions.CAPlugin.Acme
                     else
                     {
                         var authServers = await flow.StepAsync($"GetAuthoritativeDns:{domain}",
-                            async () => await dnsVerifier.GetAuthoritativeDnsServersAsync(domain));
+                            async () => await dnsVerifier.GetAuthoritativeDnsServersAsync(recordName));
 
                         if (!authServers.Any())
                         {
-                            _logger.LogWarning("Could not find authoritative DNS servers for {Domain}. This may indicate DNS delegation issues.", domain);
+                            _logger.LogWarning("Could not find authoritative DNS servers for {RecordName}. This may indicate DNS delegation issues.", recordName);
                         }
 
                         var propagated = await flow.StepAsync($"AwaitDnsPropagation:{domain}",
                             async () => await dnsVerifier.WaitForDnsPropagationAsync(
-                                validation.DnsRecordName,
+                                recordName,
                                 validation.DnsRecordValue,
                                 minimumServers: 3),
-                            detail: $"{validation.DnsRecordName} across {authServers.Count} authoritative server(s)");
+                            detail: $"{recordName} across {authServers.Count} authoritative server(s)");
 
                         if (!propagated)
                         {
@@ -769,7 +781,7 @@ namespace Keyfactor.Extensions.CAPlugin.Acme
 
                     await flow.StepAsync($"SubmitChallenge:{domain}",
                         async () => await acmeClient.AnswerChallengeAsync(challenge),
-                        detail: $"{validation.DnsRecordName}={validation.DnsRecordValue}");
+                        detail: $"{recordName}={validation.DnsRecordValue}");
                 }
             }
             finally
@@ -780,21 +792,21 @@ namespace Keyfactor.Extensions.CAPlugin.Acme
             flow.Branch("CleanupDnsRecords");
             try
             {
-                foreach (var (authz, challenge, validation, validator) in pendingChallenges)
+                foreach (var (authz, challenge, validation, validator, recordName) in pendingChallenges)
                 {
                     var domain = authz.Identifier.Value;
                     try
                     {
-                        await validator.CleanupValidation(validation.DnsRecordName, CancellationToken.None);
-                        flow.Step($"Cleanup:{domain}", detail: validation.DnsRecordName);
+                        await validator.CleanupValidation(recordName, CancellationToken.None);
+                        flow.Step($"Cleanup:{domain}", detail: recordName);
                         _logger.LogInformation("Cleaned up DNS record {RecordName} for domain {Domain}",
-                            validation.DnsRecordName, domain);
+                            recordName, domain);
                     }
                     catch (Exception ex)
                     {
                         flow.Fail($"Cleanup:{domain}", DescribeException(ex));
                         _logger.LogWarning(ex, "Failed to cleanup DNS record {RecordName} for domain {Domain}",
-                            validation.DnsRecordName, domain);
+                            recordName, domain);
                         // Continue cleanup for other domains even if one fails
                     }
                 }

--- a/AcmeCaPlugin/Clients/DNS/CnameResolver.cs
+++ b/AcmeCaPlugin/Clients/DNS/CnameResolver.cs
@@ -1,0 +1,182 @@
+// Copyright 2025 Keyfactor
+// Licensed under the Apache License, Version 2.0
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using DnsClient;
+
+namespace Keyfactor.Extensions.CAPlugin.Acme.Clients.DNS
+{
+    /// <summary>
+    /// Resolves ACME challenge record names through CNAME delegation.
+    ///
+    /// ACME DNS-01 validation requires a TXT record at _acme-challenge.&lt;domain&gt;. Many
+    /// organizations delegate that name to a separate, isolated validation zone via a CNAME
+    /// so that ACME automation never needs write access to the production zone. A TXT record
+    /// cannot coexist with a CNAME at the same name (RFC 1034), so the record must be created
+    /// at the CNAME's target, not at the original name.
+    ///
+    /// CNAME delegation can be chained multiple levels deep (A -> B -> C -> ...). This resolver
+    /// follows the chain until it reaches the terminal name that has no further CNAME, and
+    /// returns that name. If the original name has no CNAME at all, it returns the original
+    /// name unchanged, preserving the pre-delegation behavior for non-delegated domains.
+    ///
+    /// In the plugin-based DNS model the resolved terminal name is also used to select the
+    /// DNS provider plugin, so a challenge delegated into a zone on a different provider is
+    /// routed to the plugin that actually owns that zone.
+    /// </summary>
+    public class CnameResolver
+    {
+        private readonly ILogger _logger;
+        private readonly List<IPAddress> _dnsServers;
+
+        /// <summary>
+        /// Maximum number of CNAME hops to follow before giving up. Guards against
+        /// misconfigured or malicious CNAME loops and unreasonably long chains.
+        /// </summary>
+        private const int MaxCnameDepth = 10;
+
+        /// <summary>
+        /// Creates a CNAME resolver.
+        /// </summary>
+        /// <param name="logger">Logger instance</param>
+        /// <param name="verificationServer">Optional DNS server IP to query. For private/internal
+        /// delegation zones, specify the authoritative DNS server. Leave null/empty to use public
+        /// DNS servers.</param>
+        public CnameResolver(ILogger logger, string verificationServer = null)
+        {
+            _logger = logger;
+            _dnsServers = new List<IPAddress>();
+
+            if (!string.IsNullOrWhiteSpace(verificationServer) && IPAddress.TryParse(verificationServer, out var privateServer))
+            {
+                _dnsServers.Add(privateServer);
+                _logger.LogInformation("CNAME resolution will use private DNS server: {Server}", verificationServer);
+            }
+            else
+            {
+                // Public recursive resolvers. Any one that answers is sufficient.
+                _dnsServers.Add(IPAddress.Parse("8.8.8.8"));       // Google
+                _dnsServers.Add(IPAddress.Parse("1.1.1.1"));       // Cloudflare
+                _dnsServers.Add(IPAddress.Parse("9.9.9.9"));       // Quad9
+            }
+        }
+
+        /// <summary>
+        /// Resolves the record name where the ACME TXT record must actually be created,
+        /// following any chain of CNAME delegations to its terminal target.
+        /// </summary>
+        /// <param name="recordName">The ACME challenge record name from the CA
+        /// (e.g., _acme-challenge.example.com)</param>
+        /// <returns>The terminal record name to create the TXT record on. If no CNAME
+        /// delegation exists, the original name is returned unchanged.</returns>
+        public async Task<string> ResolveChallengeTargetAsync(string recordName)
+        {
+            if (string.IsNullOrWhiteSpace(recordName))
+                return recordName;
+
+            var original = Normalize(recordName);
+            var current = original;
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { current };
+
+            for (int depth = 0; depth < MaxCnameDepth; depth++)
+            {
+                var target = await QueryCnameTargetAsync(current);
+
+                if (string.IsNullOrEmpty(target))
+                {
+                    // No further CNAME at this name -> this is the terminal target.
+                    if (!string.Equals(current, original, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogInformation(
+                            "CNAME delegation resolved: {Original} -> {Target}", recordName, current);
+                    }
+                    else
+                    {
+                        _logger.LogDebug(
+                            "No CNAME delegation found for {RecordName}; using original name", recordName);
+                    }
+                    return current;
+                }
+
+                target = Normalize(target);
+
+                if (!visited.Add(target))
+                {
+                    _logger.LogWarning(
+                        "CNAME loop detected while resolving {RecordName} (revisited {Target}). Stopping at {Current}.",
+                        recordName, target, current);
+                    return current;
+                }
+
+                _logger.LogDebug("Following CNAME hop: {Current} -> {Target}", current, target);
+                current = target;
+            }
+
+            _logger.LogWarning(
+                "CNAME chain for {RecordName} exceeded maximum depth of {MaxDepth}. Using last resolved name {Current}.",
+                recordName, MaxCnameDepth, current);
+            return current;
+        }
+
+        /// <summary>
+        /// Queries a single CNAME hop for the given name. Returns the CNAME target if one
+        /// exists at this exact name, otherwise null. Tries each configured DNS server until
+        /// one answers.
+        /// </summary>
+        private async Task<string> QueryCnameTargetAsync(string name)
+        {
+            Exception lastError = null;
+
+            foreach (var dnsServer in _dnsServers)
+            {
+                try
+                {
+                    var client = new LookupClient(dnsServer);
+                    var result = await client.QueryAsync(name, QueryType.CNAME);
+
+                    // A recursive resolver may return the entire CNAME chain in one answer.
+                    // Take only the hop whose owner name matches the name we asked about so
+                    // that the caller walks the chain one deterministic step at a time.
+                    var cname = result.Answers
+                        .OfType<DnsClient.Protocol.CNameRecord>()
+                        .FirstOrDefault(r => string.Equals(
+                            Normalize(r.DomainName.Value), name, StringComparison.OrdinalIgnoreCase));
+
+                    if (cname != null)
+                        return cname.CanonicalName.Value;
+
+                    // Server answered but there is no CNAME at this name.
+                    return null;
+                }
+                catch (Exception ex)
+                {
+                    lastError = ex;
+                    _logger.LogTrace("CNAME query for {Name} against {Server} failed: {Error}",
+                        name, dnsServer, ex.Message);
+                }
+            }
+
+            // Every server errored. Treat as "no delegation discoverable" but warn, since a
+            // real CNAME that we failed to see would cause record creation to fail downstream.
+            _logger.LogWarning(
+                "Unable to query CNAME for {Name} from any DNS server: {Error}. Proceeding as if no delegation exists.",
+                name, lastError?.Message);
+            return null;
+        }
+
+        /// <summary>
+        /// Normalizes a DNS name for comparison: strips a single trailing dot and lowercases.
+        /// </summary>
+        private static string Normalize(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                return name;
+
+            return name.TrimEnd('.').ToLowerInvariant();
+        }
+    }
+}


### PR DESCRIPTION
Resolve the ACME challenge record name through any chain of CNAME delegations to its terminal target before staging validation. The resolved name now drives DNS provider plugin selection, record creation, propagation verification, and cleanup, so challenges delegated into a zone on a different provider are routed to the plugin that owns that zone. Non-delegated domains are unaffected.